### PR TITLE
Simple Random Sampling

### DIFF
--- a/src/BiodiversityObservationNetworks.jl
+++ b/src/BiodiversityObservationNetworks.jl
@@ -14,6 +14,9 @@ using LinearAlgebra
 include("types.jl")
 export BONSeeder, BONRefiner, BONSampler
 
+include("simplerandom.jl")
+export SimpleRandom
+
 include("balancedacceptance.jl")
 export BalancedAcceptance
 
@@ -25,7 +28,6 @@ export CubeSampling
 
 include("uniqueness.jl")
 export Uniqueness
-
 
 include("seed.jl")
 export seed, seed!
@@ -47,8 +49,5 @@ function __init__()
     @require SpeciesDistributionToolkit="72b53823-5c0b-4575-ad0e-8e97227ad13b" include(joinpath("integrations", "simplesdms.jl"))
     @require Zygote="e88e6eb3-aa80-5325-afca-941959d7151f" include(joinpath("integrations", "zygote.jl"))
 end=#
-
-
-
 
 end

--- a/src/simplerandom.jl
+++ b/src/simplerandom.jl
@@ -1,0 +1,29 @@
+"""
+    SimpleRandom
+
+Implements Simple Random spatial sampling (each location has equal probability of selection)
+"""
+Base.@kwdef struct SimpleRandom{I <: Integer} <: BONSeeder
+    numpoints::I = 50
+    function SimpleRandom(numpoints)
+        if numpoints < one(numpoints)
+            throw(
+                ArgumentError(
+                    "You cannot have a SimpleRandom seeder with fewer than one point",
+                ),
+            )
+        end
+        return new{typeof(numpoints)}(numpoints)
+    end
+end
+
+function _generate!(
+    coords::Vector{CartesianIndex},
+    sampler::SimpleRandom,
+    uncertainty::Matrix{T},
+) where {T <: AbstractFloat}
+    pool = CartesianIndices(uncertainty)
+
+    coords .= sample(pool, sampler.numpoints; replace = false)
+    return (coords, uncertainty)
+end


### PR DESCRIPTION
Simple Random Sampling, each cell has equal probability of inclusion $\pi_i = \frac{1}{N}$ where $N$ is total number of cells. No replacement. Notoriously not ideal for spatial sampling, but is included to be used as a baseline to compare to other methods.